### PR TITLE
PIN-4106: Create notifications only for significant events

### DIFF
--- a/src/main/scala/it/pagopa/interop/notifier/service/converters/AgreementEventsConverter.scala
+++ b/src/main/scala/it/pagopa/interop/notifier/service/converters/AgreementEventsConverter.scala
@@ -41,29 +41,41 @@ object AgreementEventsConverter {
   }
 
   private[this] def getEventNotificationPayload(event: Event): Option[NotificationPayload] = event match {
-    case AgreementAdded(a)       =>
-      AgreementPayload(agreementId = a.id.toString(), eventType = EventType.ADDED.toString()).some
-    case AgreementUpdated(a)     =>
+    case _: AgreementAdded                       =>
+      // Agreements are created with status Draft, and should not be notified
+      None
+    case AgreementUpdated(a)                     =>
       AgreementPayload(agreementId = a.id.toString(), eventType = EventType.UPDATED.toString()).some
-    case AgreementDeleted(id)    => AgreementPayload(agreementId = id, eventType = EventType.DELETED.toString()).some
-    case AgreementActivated(a)   =>
+    case _: AgreementDeleted                     =>
+      // Only agreements that have never been active can be deleted
+      None
+    case AgreementActivated(a)                   =>
+      // Never used
       AgreementPayload(agreementId = a.id.toString(), eventType = EventType.UPDATED.toString()).some
-    case AgreementSuspended(a)   =>
+    case AgreementSuspended(a)                   =>
+      // Never used
       AgreementPayload(agreementId = a.id.toString(), eventType = EventType.UPDATED.toString()).some
-    case AgreementDeactivated(a) =>
+    case AgreementDeactivated(a)                 =>
+      // Never used
       AgreementPayload(agreementId = a.id.toString(), eventType = EventType.UPDATED.toString()).some
     case AgreementConsumerDocumentAdded(id, _)   =>
+      // This operation can be done both on Draft and on Pending agreements.
+      // Ideally we should notify just the latter
       AgreementPayload(agreementId = id, eventType = EventType.UPDATED.toString()).some
     case AgreementConsumerDocumentRemoved(id, _) =>
+      // This operation can be done both on Draft and on Pending agreements.
+      // Ideally we should notify just the latter
       AgreementPayload(agreementId = id, eventType = EventType.UPDATED.toString()).some
     case VerifiedAttributeUpdated(a)             =>
+      // Never used
       AgreementPayload(
         agreementId = a.id.toString(),
         eventType = EventType.UPDATED.toString(),
         objectType = NotificationObjectType.AGREEMENT_VERIFIED_ATTRIBUTE
       ).some
     case AgreementContractAdded(id, _)           =>
-      AgreementPayload(agreementId = id, eventType = EventType.UPDATED.toString()).some
+      // We could identify this event as the creation of the agreement
+      AgreementPayload(agreementId = id, eventType = EventType.ADDED.toString()).some
   }
 
 }

--- a/src/main/scala/it/pagopa/interop/notifier/service/converters/AgreementEventsConverter.scala
+++ b/src/main/scala/it/pagopa/interop/notifier/service/converters/AgreementEventsConverter.scala
@@ -41,14 +41,12 @@ object AgreementEventsConverter {
   }
 
   private[this] def getEventNotificationPayload(event: Event): Option[NotificationPayload] = event match {
-    case _: AgreementAdded                       =>
-      // Agreements are created with status Draft, and should not be notified
-      None
+    // Agreements are created with status Draft, and should not be notified
+    case _: AgreementAdded                       => None
     case AgreementUpdated(a)                     =>
       AgreementPayload(agreementId = a.id.toString(), eventType = EventType.UPDATED.toString()).some
-    case _: AgreementDeleted                     =>
-      // Only agreements that have never been active can be deleted
-      None
+    // Only agreements that have never been active can be deleted
+    case _: AgreementDeleted                     => None
     case AgreementActivated(a)                   =>
       // Never used
       AgreementPayload(agreementId = a.id.toString(), eventType = EventType.UPDATED.toString()).some

--- a/src/main/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverter.scala
+++ b/src/main/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverter.scala
@@ -8,7 +8,6 @@ import it.pagopa.interop.notifier.service.converters.EventType._
 import it.pagopa.interop.notifier.service.impl.DynamoNotificationResourcesService
 
 import scala.concurrent.{ExecutionContext, Future}
-import it.pagopa.interop.notifier.service.converters.allOrganizations
 import cats.syntax.all._
 
 object CatalogEventsConverter {
@@ -51,29 +50,49 @@ object CatalogEventsConverter {
 
   private[this] def getEventNotificationPayload(event: Event): Option[NotificationPayload] =
     event match {
-      case CatalogItemAdded(catalogItem)       => EServicePayload(catalogItem.id.toString, None, ADDED.toString).some
-      case ClonedCatalogItemAdded(catalogItem) => EServicePayload(catalogItem.id.toString, None, CLONED.toString).some
-      case CatalogItemUpdated(catalogItem)     => EServicePayload(catalogItem.id.toString, None, UPDATED.toString).some
-      case CatalogItemWithDescriptorsDeleted(catalogItem, descriptorId)  =>
-        EServicePayload(catalogItem.id.toString, Some(descriptorId), DELETED.toString).some
-      case CatalogItemDocumentUpdated(eServiceId, descriptorId, _, _, _) =>
-        EServicePayload(eServiceId, Some(descriptorId), UPDATED.toString).some
-      case CatalogItemDeleted(catalogItemId) => EServicePayload(catalogItemId, None, DELETED.toString).some
-      case CatalogItemDocumentAdded(eServiceId, descriptorId, _, _, _) =>
-        EServicePayload(eServiceId, Some(descriptorId), UPDATED.toString).some
-      case CatalogItemDocumentDeleted(eServiceId, descriptorId, _)     =>
-        EServicePayload(eServiceId, Some(descriptorId), UPDATED.toString).some
-      case CatalogItemDescriptorAdded(eServiceId, catalogDescriptor)   =>
-        EServicePayload(eServiceId, Some(catalogDescriptor.id.toString), ADDED.toString).some
-      case CatalogItemDescriptorUpdated(eServiceId, catalogDescriptor) =>
-        EServicePayload(eServiceId, Some(catalogDescriptor.id.toString), UPDATED.toString).some
-      case CatalogItemRiskAnalysisAdded(catalogItem, _)                =>
-        EServicePayload(catalogItem.id.toString, None, UPDATED.toString).some
-      case CatalogItemRiskAnalysisDeleted(catalogItem, _)              =>
-        EServicePayload(catalogItem.id.toString, None, UPDATED.toString).some
-      case CatalogItemRiskAnalysisUpdated(catalogItem, _)              =>
-        EServicePayload(catalogItem.id.toString, None, UPDATED.toString).some
-      case MovedAttributesFromEserviceToDescriptors(_)                 => None
+      case CatalogItemDescriptorUpdated(eserviceId, _) =>
+        // Triggered for Publish, Suspension, Activation, Archive (but also for a rollback to Draft)
+        EServicePayload(eserviceId, None, UPDATED.toString).some
+      case _: CatalogItemAdded                         =>
+        // Empty EService created, should not be notified
+        None
+      case _: ClonedCatalogItemAdded                   =>
+        // Creates a Draft Descriptor, should not be notified
+        None
+      case _: CatalogItemUpdated                       =>
+        // Updates Drafts, should not be notified
+        None
+      case _: CatalogItemWithDescriptorsDeleted        =>
+        // Deleted Drafts, should not be notified
+        None
+      case _: CatalogItemDocumentUpdated               =>
+        // Document should be updated only on Drafts
+        None
+      case _: CatalogItemDeleted                       =>
+        // Deleted Drafts, should not be notified
+        None
+      case _: CatalogItemDocumentAdded                 =>
+        // Only on Drafts, should not be notified
+        None
+      case _: CatalogItemDocumentDeleted               =>
+        // Only on Drafts, should not be notified
+        None
+      case _: CatalogItemDescriptorAdded               =>
+        // Creates a Drafts, should not be notified
+        None
+      case _: CatalogItemDescriptorUpdated             =>
+        // Only on Drafts, should not be notified
+        None
+      case _: CatalogItemRiskAnalysisAdded             =>
+        // Only on Drafts, should not be notified
+        None
+      case _: CatalogItemRiskAnalysisDeleted           =>
+        // Only on Drafts, should not be notified
+        None
+      case _: CatalogItemRiskAnalysisUpdated           =>
+        // Only on Drafts, should not be notified
+        None
+      case _: MovedAttributesFromEserviceToDescriptors => None
 
     }
 

--- a/src/main/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverter.scala
+++ b/src/main/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverter.scala
@@ -51,33 +51,33 @@ object CatalogEventsConverter {
   private[this] def getEventNotificationPayload(event: Event): Option[NotificationPayload] =
     event match {
       // Empty EService created, should not be notified
-      case _: CatalogItemAdded                         => None
+      case _: CatalogItemAdded                                  => None
       // Creates a Draft Descriptor, should not be notified
-      case _: ClonedCatalogItemAdded                   => None
+      case _: ClonedCatalogItemAdded                            => None
       // Updates Drafts, should not be notified
-      case _: CatalogItemUpdated                       => None
+      case _: CatalogItemUpdated                                => None
       // Deleted Drafts, should not be notified
-      case _: CatalogItemWithDescriptorsDeleted        => None
+      case _: CatalogItemWithDescriptorsDeleted                 => None
       // Document should be updated only on Drafts
-      case _: CatalogItemDocumentUpdated               => None
+      case _: CatalogItemDocumentUpdated                        => None
       // Deleted Drafts, should not be notified
-      case _: CatalogItemDeleted                       => None
+      case _: CatalogItemDeleted                                => None
       // Only on Drafts, should not be notified
-      case _: CatalogItemDocumentAdded                 => None
+      case _: CatalogItemDocumentAdded                          => None
       // Only on Drafts, should not be notified
-      case _: CatalogItemDocumentDeleted               => None
+      case _: CatalogItemDocumentDeleted                        => None
       // Creates a Drafts, should not be notified
-      case _: CatalogItemDescriptorAdded               => None
-      case CatalogItemDescriptorUpdated(eserviceId, _) =>
+      case _: CatalogItemDescriptorAdded                        => None
+      case CatalogItemDescriptorUpdated(eserviceId, descriptor) =>
         // Triggered for Publish, Suspension, Activation, Archive (but also for a rollback to Draft)
-        EServicePayload(eserviceId, None, UPDATED.toString).some
+        EServicePayload(eserviceId, descriptor.id.toString.some, UPDATED.toString).some
       // Only on Drafts, should not be notified
-      case _: CatalogItemRiskAnalysisAdded             => None
+      case _: CatalogItemRiskAnalysisAdded                      => None
       // Only on Drafts, should not be notified
-      case _: CatalogItemRiskAnalysisDeleted           => None
+      case _: CatalogItemRiskAnalysisDeleted                    => None
       // Only on Drafts, should not be notified
-      case _: CatalogItemRiskAnalysisUpdated           => None
-      case _: MovedAttributesFromEserviceToDescriptors => None
+      case _: CatalogItemRiskAnalysisUpdated                    => None
+      case _: MovedAttributesFromEserviceToDescriptors          => None
 
     }
 

--- a/src/main/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverter.scala
+++ b/src/main/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverter.scala
@@ -53,45 +53,32 @@ object CatalogEventsConverter {
       case CatalogItemDescriptorUpdated(eserviceId, _) =>
         // Triggered for Publish, Suspension, Activation, Archive (but also for a rollback to Draft)
         EServicePayload(eserviceId, None, UPDATED.toString).some
-      case _: CatalogItemAdded                         =>
-        // Empty EService created, should not be notified
-        None
-      case _: ClonedCatalogItemAdded                   =>
-        // Creates a Draft Descriptor, should not be notified
-        None
-      case _: CatalogItemUpdated                       =>
-        // Updates Drafts, should not be notified
-        None
-      case _: CatalogItemWithDescriptorsDeleted        =>
-        // Deleted Drafts, should not be notified
-        None
-      case _: CatalogItemDocumentUpdated               =>
-        // Document should be updated only on Drafts
-        None
-      case _: CatalogItemDeleted                       =>
-        // Deleted Drafts, should not be notified
-        None
-      case _: CatalogItemDocumentAdded                 =>
-        // Only on Drafts, should not be notified
-        None
-      case _: CatalogItemDocumentDeleted               =>
-        // Only on Drafts, should not be notified
-        None
-      case _: CatalogItemDescriptorAdded               =>
-        // Creates a Drafts, should not be notified
-        None
-      case _: CatalogItemDescriptorUpdated             =>
-        // Only on Drafts, should not be notified
-        None
-      case _: CatalogItemRiskAnalysisAdded             =>
-        // Only on Drafts, should not be notified
-        None
-      case _: CatalogItemRiskAnalysisDeleted           =>
-        // Only on Drafts, should not be notified
-        None
-      case _: CatalogItemRiskAnalysisUpdated           =>
-        // Only on Drafts, should not be notified
-        None
+      // Empty EService created, should not be notified
+      case _: CatalogItemAdded                         => None
+      // Creates a Draft Descriptor, should not be notified
+      case _: ClonedCatalogItemAdded                   => None
+      // Updates Drafts, should not be notified
+      case _: CatalogItemUpdated                       => None
+      // Deleted Drafts, should not be notified
+      case _: CatalogItemWithDescriptorsDeleted        => None
+      // Document should be updated only on Drafts
+      case _: CatalogItemDocumentUpdated               => None
+      // Deleted Drafts, should not be notified
+      case _: CatalogItemDeleted                       => None
+      // Only on Drafts, should not be notified
+      case _: CatalogItemDocumentAdded                 => None
+      // Only on Drafts, should not be notified
+      case _: CatalogItemDocumentDeleted               => None
+      // Creates a Drafts, should not be notified
+      case _: CatalogItemDescriptorAdded               => None
+      // Only on Drafts, should not be notified
+      case _: CatalogItemDescriptorUpdated             => None
+      // Only on Drafts, should not be notified
+      case _: CatalogItemRiskAnalysisAdded             => None
+      // Only on Drafts, should not be notified
+      case _: CatalogItemRiskAnalysisDeleted           => None
+      // Only on Drafts, should not be notified
+      case _: CatalogItemRiskAnalysisUpdated           => None
       case _: MovedAttributesFromEserviceToDescriptors => None
 
     }

--- a/src/main/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverter.scala
+++ b/src/main/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverter.scala
@@ -50,9 +50,6 @@ object CatalogEventsConverter {
 
   private[this] def getEventNotificationPayload(event: Event): Option[NotificationPayload] =
     event match {
-      case CatalogItemDescriptorUpdated(eserviceId, _) =>
-        // Triggered for Publish, Suspension, Activation, Archive (but also for a rollback to Draft)
-        EServicePayload(eserviceId, None, UPDATED.toString).some
       // Empty EService created, should not be notified
       case _: CatalogItemAdded                         => None
       // Creates a Draft Descriptor, should not be notified
@@ -71,8 +68,9 @@ object CatalogEventsConverter {
       case _: CatalogItemDocumentDeleted               => None
       // Creates a Drafts, should not be notified
       case _: CatalogItemDescriptorAdded               => None
-      // Only on Drafts, should not be notified
-      case _: CatalogItemDescriptorUpdated             => None
+      case CatalogItemDescriptorUpdated(eserviceId, _) =>
+        // Triggered for Publish, Suspension, Activation, Archive (but also for a rollback to Draft)
+        EServicePayload(eserviceId, None, UPDATED.toString).some
       // Only on Drafts, should not be notified
       case _: CatalogItemRiskAnalysisAdded             => None
       // Only on Drafts, should not be notified

--- a/src/main/scala/it/pagopa/interop/notifier/service/converters/PurposeEventsConverter.scala
+++ b/src/main/scala/it/pagopa/interop/notifier/service/converters/PurposeEventsConverter.scala
@@ -57,28 +57,22 @@ object PurposeEventsConverter {
 
   private[this] def getEventNotificationPayload(event: Event): Option[NotificationPayload] =
     event match {
-      case _: PurposeCreated                        =>
-        // Creates Drafts, should not be notified
-        None
-      case _: PurposeUpdated                        =>
-        // Only on Drafts, should not be notified
-        None
-      case _: PurposeVersionCreated                 =>
-        // Creates Drafts, should not be notified
-        None
+      // Creates Drafts, should not be notified
+      case _: PurposeCreated                        => None
+      // Only on Drafts, should not be notified
+      case _: PurposeUpdated                        => None
+      // Creates Drafts, should not be notified
+      case _: PurposeVersionCreated                 => None
       case PurposeVersionActivated(purpose)         => PurposePayload(purpose.id.toString(), ACTIVATED.toString()).some
       case PurposeVersionSuspended(purpose)         => PurposePayload(purpose.id.toString(), SUSPENDED.toString()).some
       case PurposeVersionWaitedForApproval(purpose) =>
         PurposePayload(purpose.id.toString(), WAITING_FOR_APPROVAL.toString).some
       case PurposeVersionArchived(purpose)          => PurposePayload(purpose.id.toString(), ARCHIVED.toString()).some
-      case _: PurposeVersionUpdated                 =>
-        // Only on Drafts, should not be notified
-        None
-      case _: PurposeVersionDeleted                 =>
-        // Only on Drafts, should not be notified
-        None
-      case _: PurposeDeleted                        =>
-        // Only on Drafts, should not be notified
-        None
+      // Only on Drafts, should not be notified
+      case _: PurposeVersionUpdated                 => None
+      // Only on Drafts, should not be notified
+      case _: PurposeVersionDeleted                 => None
+      // Only on Drafts, should not be notified
+      case _: PurposeDeleted                        => None
     }
 }

--- a/src/main/scala/it/pagopa/interop/notifier/service/converters/PurposeEventsConverter.scala
+++ b/src/main/scala/it/pagopa/interop/notifier/service/converters/PurposeEventsConverter.scala
@@ -57,16 +57,28 @@ object PurposeEventsConverter {
 
   private[this] def getEventNotificationPayload(event: Event): Option[NotificationPayload] =
     event match {
-      case PurposeCreated(purpose)                  => PurposePayload(purpose.id.toString(), CREATED.toString()).some
-      case PurposeUpdated(purpose)                  => PurposePayload(purpose.id.toString(), UPDATED.toString()).some
-      case PurposeVersionCreated(purposeId, _)      => PurposePayload(purposeId, CREATED.toString).some
+      case _: PurposeCreated                        =>
+        // Creates Drafts, should not be notified
+        None
+      case _: PurposeUpdated                        =>
+        // Only on Drafts, should not be notified
+        None
+      case _: PurposeVersionCreated                 =>
+        // Creates Drafts, should not be notified
+        None
       case PurposeVersionActivated(purpose)         => PurposePayload(purpose.id.toString(), ACTIVATED.toString()).some
       case PurposeVersionSuspended(purpose)         => PurposePayload(purpose.id.toString(), SUSPENDED.toString()).some
       case PurposeVersionWaitedForApproval(purpose) =>
         PurposePayload(purpose.id.toString(), WAITING_FOR_APPROVAL.toString).some
       case PurposeVersionArchived(purpose)          => PurposePayload(purpose.id.toString(), ARCHIVED.toString()).some
-      case PurposeVersionUpdated(purposeId, _)      => PurposePayload(purposeId, UPDATED.toString()).some
-      case PurposeVersionDeleted(purposeId, _)      => PurposePayload(purposeId, DELETED.toString()).some
-      case PurposeDeleted(purposeId)                => PurposePayload(purposeId, DELETED.toString()).some
+      case _: PurposeVersionUpdated                 =>
+        // Only on Drafts, should not be notified
+        None
+      case _: PurposeVersionDeleted                 =>
+        // Only on Drafts, should not be notified
+        None
+      case _: PurposeDeleted                        =>
+        // Only on Drafts, should not be notified
+        None
     }
 }

--- a/src/main/scala/it/pagopa/interop/notifier/service/impl/CatalogManagementServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/notifier/service/impl/CatalogManagementServiceImpl.scala
@@ -18,10 +18,8 @@ final class CatalogManagementServiceImpl(invoker: CatalogManagementInvoker, api:
     Logger.takingImplicit[ContextFieldsToLog](this.getClass)
 
   private[this] def getEServiceById(eServiceId: UUID)(implicit contexts: Seq[(String, String)]): Future[EService] =
-    withHeaders { (bearerToken, correlationId, ip) =>
-      val request = api.getEService(xCorrelationId = correlationId, eServiceId.toString, xForwardedFor = ip)(
-        BearerToken(bearerToken)
-      )
+    withHeaders { (bearerToken, correlationId) =>
+      val request = api.getEService(xCorrelationId = correlationId, eServiceId.toString)(BearerToken(bearerToken))
       invoker.invoke(request, s"Retrieving EService $eServiceId")
     }
 

--- a/src/test/scala/it/pagopa/interop/notifier/model/DynamoMessageSpec.scala
+++ b/src/test/scala/it/pagopa/interop/notifier/model/DynamoMessageSpec.scala
@@ -1,18 +1,18 @@
 package it.pagopa.interop.notifier.model
 
+import cats.syntax.all._
 import it.pagopa.interop.agreementmanagement.model.agreement.{Active, PersistentAgreement, PersistentStamps}
 import it.pagopa.interop.agreementmanagement.model.persistence.AgreementActivated
 import it.pagopa.interop.commons.queue.message.Message
 import it.pagopa.interop.commons.utils.errors.ComponentError
-import it.pagopa.interop.notifier.service.converters.EventType.{CREATED, UPDATED}
-import it.pagopa.interop.purposemanagement.model.persistence.PurposeCreated
+import it.pagopa.interop.notifier.service.converters.EventType.{ACTIVATED, UPDATED}
+import it.pagopa.interop.purposemanagement.model.persistence.PurposeVersionActivated
 import it.pagopa.interop.purposemanagement.model.purpose.PersistentPurpose
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import java.time.OffsetDateTime
 import java.util.UUID
-import cats.syntax.all._
 
 class DynamoMessageSpec extends AnyWordSpecLike with Matchers {
 
@@ -41,7 +41,7 @@ class DynamoMessageSpec extends AnyWordSpecLike with Matchers {
         isFreeOfCharge = true,
         freeOfChargeReason = Some("BOH")
       )
-      val event = PurposeCreated(pp)
+      val event = PurposeVersionActivated(pp)
 
       val message =
         Message(messageId, eventJournalPersistenceId, eventJournalSequenceNumber, eventTimestamp, kind, payload = event)
@@ -60,7 +60,7 @@ class DynamoMessageSpec extends AnyWordSpecLike with Matchers {
         eventJournalPersistenceId = eventJournalPersistenceId,
         eventJournalSequenceNumber = eventJournalSequenceNumber,
         eventTimestamp = eventTimestamp,
-        payload = PurposePayload(id.toString, CREATED.toString),
+        payload = PurposePayload(id.toString, ACTIVATED.toString),
         resourceId = id.toString
       )
       conversion shouldBe Right(expected.some)

--- a/src/test/scala/it/pagopa/interop/notifier/service/converters/AgreementEventsConverterSpec.scala
+++ b/src/test/scala/it/pagopa/interop/notifier/service/converters/AgreementEventsConverterSpec.scala
@@ -16,7 +16,7 @@ class AgreementEventsConverterSpec extends AnyWordSpecLike with Matchers with Sc
 
   "Agreement conversions" should {
 
-    "Convert purpose created to event payload" in {
+    "Convert agreement created to event payload" in {
       // given
       val id = UUID.randomUUID()
       val a  = getAgreement(id)
@@ -26,10 +26,10 @@ class AgreementEventsConverterSpec extends AnyWordSpecLike with Matchers with Sc
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         AgreementEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(AgreementPayload(id.toString, EventType.ADDED.toString).some)
+      conversion shouldBe Right(None)
     }
 
-    "Convert purpose deleted to event payload" in {
+    "Convert agreement deleted to event payload" in {
       // given
       val id = UUID.randomUUID()
       val e  = AgreementDeleted(id.toString)
@@ -38,10 +38,10 @@ class AgreementEventsConverterSpec extends AnyWordSpecLike with Matchers with Sc
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         AgreementEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(AgreementPayload(id.toString, EventType.DELETED.toString).some)
+      conversion shouldBe Right(None)
     }
 
-    "Convert purpose updated to event payload" in {
+    "Convert agreement updated to event payload" in {
       // given
       val id = UUID.randomUUID()
       val a  = getAgreement(id)
@@ -54,7 +54,7 @@ class AgreementEventsConverterSpec extends AnyWordSpecLike with Matchers with Sc
       conversion shouldBe Right(AgreementPayload(id.toString, EventType.UPDATED.toString).some)
     }
 
-    "Convert purpose activated to event payload" in {
+    "Convert agreement activated to event payload" in {
       // given
       val id = UUID.randomUUID()
       val a  = getAgreement(id)
@@ -67,7 +67,7 @@ class AgreementEventsConverterSpec extends AnyWordSpecLike with Matchers with Sc
       conversion shouldBe Right(AgreementPayload(id.toString, EventType.UPDATED.toString).some)
     }
 
-    "Convert purpose suspended to event payload" in {
+    "Convert agreement suspended to event payload" in {
       // given
       val id = UUID.randomUUID()
       val a  = getAgreement(id)
@@ -80,7 +80,7 @@ class AgreementEventsConverterSpec extends AnyWordSpecLike with Matchers with Sc
       conversion shouldBe Right(AgreementPayload(id.toString, EventType.UPDATED.toString).some)
     }
 
-    "Convert purpose deactivated to event payload" in {
+    "Convert agreement deactivated to event payload" in {
       // given
       val id = UUID.randomUUID()
       val a  = getAgreement(id)

--- a/src/test/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverterSpec.scala
+++ b/src/test/scala/it/pagopa/interop/notifier/service/converters/CatalogEventsConverterSpec.scala
@@ -1,7 +1,7 @@
 package it.pagopa.interop.notifier.service.converters
 
-import it.pagopa.interop.catalogmanagement.model.persistence._
 import it.pagopa.interop.catalogmanagement.model._
+import it.pagopa.interop.catalogmanagement.model.persistence._
 import it.pagopa.interop.commons.utils.errors.ComponentError
 import it.pagopa.interop.notifier.model.{EServicePayload, NotificationPayload}
 import org.scalatest.concurrent.ScalaFutures
@@ -26,7 +26,7 @@ class CatalogEventsConverterSpec extends AnyWordSpecLike with Matchers with Scal
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         CatalogEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(EServicePayload(id.toString, None, EventType.ADDED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert catalog cloned to event payload" in {
@@ -39,7 +39,7 @@ class CatalogEventsConverterSpec extends AnyWordSpecLike with Matchers with Scal
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         CatalogEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(EServicePayload(id.toString, None, EventType.CLONED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert catalog updated to event payload" in {
@@ -52,7 +52,7 @@ class CatalogEventsConverterSpec extends AnyWordSpecLike with Matchers with Scal
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         CatalogEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(EServicePayload(id.toString, None, EventType.UPDATED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert catalog with descriptor delete to event payload" in {
@@ -66,9 +66,7 @@ class CatalogEventsConverterSpec extends AnyWordSpecLike with Matchers with Scal
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         CatalogEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(
-        EServicePayload(id.toString, Some(descriptorId.toString), EventType.DELETED.toString).some
-      )
+      conversion shouldBe Right(None)
     }
 
     "Convert catalog document updated to event payload" in {
@@ -83,9 +81,7 @@ class CatalogEventsConverterSpec extends AnyWordSpecLike with Matchers with Scal
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         CatalogEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(
-        EServicePayload(id.toString, Some(descriptorId.toString), EventType.UPDATED.toString).some
-      )
+      conversion shouldBe Right(None)
     }
 
     "Convert catalog deleted to event payload" in {
@@ -98,7 +94,7 @@ class CatalogEventsConverterSpec extends AnyWordSpecLike with Matchers with Scal
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         CatalogEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(EServicePayload(id.toString, None, EventType.DELETED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert catalog document added to event payload" in {
@@ -113,9 +109,7 @@ class CatalogEventsConverterSpec extends AnyWordSpecLike with Matchers with Scal
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         CatalogEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(
-        EServicePayload(id.toString, Some(descriptorId.toString), EventType.UPDATED.toString).some
-      )
+      conversion shouldBe Right(None)
     }
 
     "Convert catalog document deleted to event payload" in {
@@ -129,9 +123,7 @@ class CatalogEventsConverterSpec extends AnyWordSpecLike with Matchers with Scal
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         CatalogEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(
-        EServicePayload(id.toString, Some(descriptorId.toString), EventType.UPDATED.toString).some
-      )
+      conversion shouldBe Right(None)
     }
 
     "Convert catalog descriptor added to event payload" in {
@@ -145,9 +137,7 @@ class CatalogEventsConverterSpec extends AnyWordSpecLike with Matchers with Scal
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         CatalogEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(
-        EServicePayload(id.toString, Some(descriptorId.toString), EventType.ADDED.toString).some
-      )
+      conversion shouldBe Right(None)
     }
 
     "Convert catalog descriptor updated to event payload" in {

--- a/src/test/scala/it/pagopa/interop/notifier/service/converters/PurposeEventsConverterSpec.scala
+++ b/src/test/scala/it/pagopa/interop/notifier/service/converters/PurposeEventsConverterSpec.scala
@@ -25,7 +25,7 @@ class PurposeEventsConverterSpec extends AnyWordSpecLike with Matchers {
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         PurposeEventsConverter.asNotificationPayload(p)
       // then
-      conversion shouldBe Right(PurposePayload(id.toString, EventType.CREATED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert purpose updated to event payload" in {
@@ -38,7 +38,7 @@ class PurposeEventsConverterSpec extends AnyWordSpecLike with Matchers {
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         PurposeEventsConverter.asNotificationPayload(p)
       // then
-      conversion shouldBe Right(PurposePayload(id.toString, EventType.UPDATED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert purpose version created to event payload" in {
@@ -52,7 +52,7 @@ class PurposeEventsConverterSpec extends AnyWordSpecLike with Matchers {
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         PurposeEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(PurposePayload(id.toString, EventType.CREATED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert purpose activated to event payload" in {
@@ -105,7 +105,7 @@ class PurposeEventsConverterSpec extends AnyWordSpecLike with Matchers {
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         PurposeEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(PurposePayload(id.toString, EventType.UPDATED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert purpose version deleted to event payload" in {
@@ -118,7 +118,7 @@ class PurposeEventsConverterSpec extends AnyWordSpecLike with Matchers {
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         PurposeEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(PurposePayload(id.toString, EventType.DELETED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert purpose deleted to event payload" in {
@@ -130,7 +130,7 @@ class PurposeEventsConverterSpec extends AnyWordSpecLike with Matchers {
       val conversion: Either[ComponentError, Option[NotificationPayload]] =
         PurposeEventsConverter.asNotificationPayload(e)
       // then
-      conversion shouldBe Right(PurposePayload(id.toString, EventType.DELETED.toString).some)
+      conversion shouldBe Right(None)
     }
 
     "Convert purpose waited for approval to event payload" in {


### PR DESCRIPTION
Before this PR basically each event was producing a notification, despite the fact that some events may not be useful because they do not have effect on the platform.
For example, should the creation of a DRAFT Agreement be notified? Or of a DRAFT EService not yet visibile in the catalog?

The current PR avoids the creation of notifications for all events considered not required.